### PR TITLE
Fix code coverage with pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,18 @@ src_paths = ["llm_api_client", "tests"]
 branch = true
 source = ["llm_api_client"]
 omit = ["llm_api_client/_version.py", "tests"]
+concurrency = ["thread"]
+parallel = true
+relative_files = true
 
 [tool.coverage.report]
 show_missing = true
+
+[tool.coverage.paths]
+source = [
+    "llm_api_client",
+    ".tox/*/lib/python*/site-packages/llm_api_client",
+]
 
 # MyPy
 [tool.mypy]
@@ -119,12 +128,15 @@ env_list =
 
 [testenv]
 description = run unit tests
+usedevelop = true
+changedir = {toxinidir}
 deps =
     pytest>=8
     pytest-cov>=4
     pytest-xdist>=3
+    coverage>=7.2
 commands =
-    pytest --cov=llm_api_client --cov-branch {posargs:tests}
+    pytest --cov=llm_api_client --cov-branch -n auto {posargs:tests}
 
 [testenv:type]
 description = run type checks

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,6 @@
 pytest>=8
 pytest-cov>=4
+coverage>=7.2
 flake8-pyproject
 flake8
 mypy>=1.0


### PR DESCRIPTION
Fixes inaccurate code coverage reports in CI when using `pytest-xdist`.

The previous configuration did not correctly merge coverage data from parallel test runs or properly map source files when the package was installed within tox virtual environments, leading to 0% coverage. This PR configures `coverage.py` to handle parallel data collection and correctly identify source paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-18f659ee-bd93-481c-927e-65016327312b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18f659ee-bd93-481c-927e-65016327312b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

