### PR TITLE
Override litellm max input tokens with env var

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -11,8 +11,8 @@ Client limits
 Environment variables
 ---------------------
 
-- **DEFAULT_MAX_CONTEXT_TOKENS**: Maximum context window tokens used by the sanitizer
-  to truncate long message histories (default: 20000).
+- **MAX_CONTEXT_TOKENS_FALLBACK**: Fallback maximum context window tokens used by the sanitizer
+  to truncate long message histories when LiteLLM info isn't available (default: 100000).
 - **MAX_INPUT_TOKENS_OVERRIDE**: When set to an integer, this value is used as the
   model's maximum input tokens, taking precedence over the value reported by LiteLLM.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,6 +13,8 @@ Environment variables
 
 - **DEFAULT_MAX_CONTEXT_TOKENS**: Maximum context window tokens used by the sanitizer
   to truncate long message histories (default: 20000).
+- **MAX_INPUT_TOKENS_OVERRIDE**: When set to an integer, this value is used as the
+  model's maximum input tokens, taking precedence over the value reported by LiteLLM.
 
 Provider credentials
 --------------------

--- a/llm_api_client/api_client.py
+++ b/llm_api_client/api_client.py
@@ -29,6 +29,7 @@ except ValueError:
         f"Environment variable {DEFAULT_MAX_CONTEXT_TOKENS_ENV_VAR} must be an integer. "
         "Falling back to 100,000 tokens.")
     DEFAULT_MAX_CONTEXT_TOKENS = 100_000
+MAX_INPUT_TOKENS_OVERRIDE_ENV_VAR = "MAX_INPUT_TOKENS_OVERRIDE"
 
 
 class APIClient:
@@ -432,6 +433,14 @@ class APIClient:
 
     def get_max_context_tokens(self, model: str) -> int:
         """Get the maximum context tokens for a model."""
+        # Allow env override to take precedence over LiteLLM-reported value
+        override_value_str = os.getenv(MAX_INPUT_TOKENS_OVERRIDE_ENV_VAR)
+        if override_value_str:
+            try:
+                return int(override_value_str)
+            except ValueError:
+                self._logger.warning(
+                    f"Environment variable {MAX_INPUT_TOKENS_OVERRIDE_ENV_VAR} must be an integer. Ignoring override.")
         try:
             model_info = litellm.get_model_info(model)
             max_tokens = model_info.get("max_input_tokens")

--- a/llm_api_client/api_client.py
+++ b/llm_api_client/api_client.py
@@ -20,13 +20,13 @@ from ._params import ALL_COMPLETION_PARAMS
 OPENAI_API_REQUESTS_PER_MINUTE = 10_000
 OPENAI_API_TOKENS_PER_MINUTE = 2_000_000
 
-# Default max context window tokens
-DEFAULT_MAX_CONTEXT_TOKENS_ENV_VAR = "DEFAULT_MAX_CONTEXT_TOKENS"
+# Default max context window tokens fallback
+MAX_CONTEXT_TOKENS_FALLBACK_ENV_VAR = "MAX_CONTEXT_TOKENS_FALLBACK"
 try:
-    DEFAULT_MAX_CONTEXT_TOKENS = int(os.getenv(DEFAULT_MAX_CONTEXT_TOKENS_ENV_VAR, "100000"))
+    DEFAULT_MAX_CONTEXT_TOKENS = int(os.getenv(MAX_CONTEXT_TOKENS_FALLBACK_ENV_VAR, "100000"))
 except ValueError:
     logging.getLogger(__name__).warning(
-        f"Environment variable {DEFAULT_MAX_CONTEXT_TOKENS_ENV_VAR} must be an integer. "
+        f"Environment variable {MAX_CONTEXT_TOKENS_FALLBACK_ENV_VAR} must be an integer. "
         "Falling back to 100,000 tokens.")
     DEFAULT_MAX_CONTEXT_TOKENS = 100_000
 MAX_INPUT_TOKENS_OVERRIDE_ENV_VAR = "MAX_INPUT_TOKENS_OVERRIDE"


### PR DESCRIPTION
Add `MAX_INPUT_TOKENS_OVERRIDE` environment variable to allow overriding potentially incorrect `max_input_tokens` values reported by LiteLLM.

---
<a href="https://cursor.com/background-agent?bcId=bc-8612755b-b98c-4964-8361-c7e363e38a9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8612755b-b98c-4964-8361-c7e363e38a9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

